### PR TITLE
parsesmi: support LF and CRLF line endings

### DIFF
--- a/detecteyemovements.m
+++ b/detecteyemovements.m
@@ -186,7 +186,7 @@ else
     fprintf('\nVelocity threshold factor (vfac):  %.2f SD',vfac);
     fprintf('\nMinimum saccade duration (mindur): %.2f samples (%.2f ms)',mindur,mindur*1000/EEG.srate);
     if ~isempty(degperpixel) | isnan(degperpixel) % bugfix 2016-11-12 by OD: added case if degperpixel = NaN (from GUI input)
-        fprintf('\nVisual angle per screen pixel:     %f°',degperpixel);
+        fprintf('\nVisual angle per screen pixel:     %fï¿½',degperpixel);
         metric = 'deg';
     else
         fprintf('\nWARNING: No input provided for degperpixel!\nSpatial saccade properties are given in original metric (pixel?)');
@@ -635,8 +635,8 @@ end
 %% user feedback: saccade & fixation detection
 fprintf('\n--------------------------------------------------------------------');
 fprintf('\nVelocity thresholds used:'); if nepochs > 1, fprintf(' (mean across epochs):'); end
-if ldata, fprintf('\n\tLeft eye.  Horiz.: %.2f %s/s. Vert.: %.2f %s/s',mean(l_msdx(e)*vfac*degperpixel),metric,mean(l_msdy*vfac*degperpixel),metric); end
-if rdata, fprintf('\n\tRight eye. Horiz.: %.2f %s/s. Vert.: %.2f %s/s',mean(r_msdx(e)*vfac*degperpixel),metric,mean(r_msdy*vfac*degperpixel),metric); end
+if ldata, fprintf('\n\tLeft eye.  Horiz.: %.2f %s/s. Vert.: %.2f %s/s',mean(l_msdx*vfac*degperpixel),metric,mean(l_msdy*vfac*degperpixel),metric); end
+if rdata, fprintf('\n\tRight eye. Horiz.: %.2f %s/s. Vert.: %.2f %s/s',mean(r_msdx*vfac*degperpixel),metric,mean(r_msdy*vfac*degperpixel),metric); end
 fprintf('\n--------------------------------------------------------------------')
 if ~isempty(allsac)
     fprintf('\n%i saccades detected:',size(allsac,1));

--- a/parsesmi.m
+++ b/parsesmi.m
@@ -73,10 +73,10 @@ fprintf('\n\tDone.')
 
 %% file specifications and comments
 fprintf('\n-- getting comment lines and column headers...')
-et.comments = regexp(B,'(##[^\r\n]*\r\n)','match');
+et.comments = regexp(B,'(##[^\r\n]*\r?\n)','match');
 
 %% build column header
-et.colheader = regexp(B,'Time[^\r\n]*\r\n','match');
+et.colheader = regexp(B,'Time[^\r\n]*\r?\n','match');
 
 % clear 'Type' from header, as this information is not kept
 et.colheader = strrep(et.colheader,sprintf('Type\t'),'');
@@ -120,7 +120,7 @@ end
 
 %% get messages
 fprintf('\n-- getting messages...')
-et.messages = regexp(B,'\d*\tMSG[^\r\n]*\r\n','match');
+et.messages = regexp(B,'\d*\tMSG[^\r\n]*\r?\n','match');
 fprintf('\n\tDone.')
 
 %% build table with synchronization events for eye tracker


### PR DESCRIPTION
Hello

I've encountered 2 small bugs working with EYE-EEG:

1. In my setup, I had to rewrite SMI sample files before calling `parsesmi`, causing the file to use linux style line endings:

```matlab
filename = '/path/to/subject_task_Samples.txt';
lines = readlines(filename);
sync_lines = regexprep(lines, '(# Message:\s)(\d+)', '$1SYNC $2');

lf_txt = fullfile(tempdir, 'sync_lf.txt');
lf_mat = fullfile(tempdir, 'sync_lf.mat');

writelines(sync_lines, lf_txt);   % writes LF-only on Linux
et_lf = parsesmi(lf_txt, lf_mat, 'SYNC');
```

With the current version of parsesmi, this crashes with:

```matlab
parsesmi(): Parsing Sensomotoric Instruments (IView X/RED) raw data. This may take a moment...
-- reading txt...
    Done.
-- getting comment lines and column headers...
    Done.
-- getting data (this may take a moment...
    Done.
-- getting messages...
    Done.
Error using cellfun
Input #2 expected to be a cell array, was double instead.

Error in parsesmi (line 140)
    test3 = cellfun(@str2double,test2,'UniformOutput',false);
```

Changing the regexes in `parsesmi.m` to match "\r?\n" (like in `parseeyelink.m`) fixes this.


2. In `detecteyemovements.m`, the final console summary says it prints the velocity thresholds as the mean across epochs, but the horizontal threshold was actually taken from `l_msdx(e)` / `r_msdx(e)`, where `e` is the last epoch index from the loop. As a result, the horizontal threshold reflected only the last epoch. This only affects the console summary and can be fixed by removing the index